### PR TITLE
Lock attested assets

### DIFF
--- a/pallets/liquidity-provider/src/lib.rs
+++ b/pallets/liquidity-provider/src/lib.rs
@@ -2,12 +2,11 @@
 
 use frame_support::{decl_error, decl_event, decl_module, dispatch};
 use frame_system::ensure_signed;
-use orml_traits::MultiCurrency;
+use orml_traits::{MultiCurrency, MultiReservableCurrency};
 use valiu_node_commons::Asset;
 
 #[cfg(test)]
 mod mock;
-
 #[cfg(test)]
 mod tests;
 
@@ -15,9 +14,8 @@ type BalanceOf<T> =
     <<T as Trait>::Currency as MultiCurrency<<T as frame_system::Trait>::AccountId>>::Balance;
 
 pub trait Trait: pallet_membership::Trait {
-    /// Because this pallet emits events, it depends on the runtime's definition of an event.
+    type Currency: MultiReservableCurrency<Self::AccountId, CurrencyId = Asset>;
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
-    type Currency: MultiCurrency<Self::AccountId, CurrencyId = Asset>;
 }
 
 decl_event!(
@@ -25,16 +23,14 @@ decl_event!(
     where
         AccountId = <T as frame_system::Trait>::AccountId,
     {
-        /// Event documentation should end with an array that provides descriptive names for event
-        /// parameters. [something, who]
         Attestation(AccountId, Asset),
     }
 );
 
 decl_error! {
     pub enum Error for Module<T: Trait> {
+        MustNotBeUsdv,
         NotAProvider,
-        MustNotBeUsdv
     }
 }
 
@@ -56,6 +52,7 @@ decl_module! {
             members.binary_search(&provider).map_err(|_| Error::<T>::NotAProvider)?;
 
             T::Currency::deposit(asset_id, &provider, balance)?;
+            T::Currency::reserve(asset_id, &provider, balance)?;
             Self::deposit_event(RawEvent::Attestation(provider, asset_id));
             Ok(())
         }

--- a/pallets/liquidity-provider/src/tests.rs
+++ b/pallets/liquidity-provider/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{mock::*, Error};
 use frame_support::{assert_noop, assert_ok};
+use orml_traits::MultiReservableCurrency;
 use sp_runtime::traits::BadOrigin;
 use valiu_node_commons::Asset;
 
@@ -12,8 +13,14 @@ fn attest_increases_asset_supply() {
         assert_ok!(Membership::add_member(Origin::signed(ROOT), 2));
         assert_ok!(Membership::add_member(Origin::signed(ROOT), 3));
 
-        assert_ok!(TestProvider::attest(Origin::signed(2), BTC, 123));
-        assert_ok!(TestProvider::attest(Origin::signed(3), BTC, 456));
+        let member_2 = Origin::signed(2);
+        assert_ok!(TestProvider::attest(member_2, BTC, 123));
+        assert_eq!(Tokens::reserved_balance(BTC, &2), 123);
+
+        let member_3 = Origin::signed(3);
+        assert_ok!(TestProvider::attest(member_3, BTC, 456));
+        assert_eq!(Tokens::reserved_balance(BTC, &3), 456);
+
         assert_eq!(Tokens::total_issuance(BTC), 579);
     });
 }

--- a/pallets/liquidity-provider/src/tests.rs
+++ b/pallets/liquidity-provider/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{mock::*, Error};
 use frame_support::{assert_noop, assert_ok};
-use orml_traits::MultiReservableCurrency;
+use orml_traits::{MultiCurrency, MultiReservableCurrency};
 use sp_runtime::traits::BadOrigin;
 use valiu_node_commons::Asset;
 
@@ -15,10 +15,12 @@ fn attest_increases_asset_supply() {
 
         let member_2 = Origin::signed(2);
         assert_ok!(TestProvider::attest(member_2, BTC, 123));
+        assert_eq!(Tokens::free_balance(BTC, &2), 0);
         assert_eq!(Tokens::reserved_balance(BTC, &2), 123);
 
         let member_3 = Origin::signed(3);
         assert_ok!(TestProvider::attest(member_3, BTC, 456));
+        assert_eq!(Tokens::free_balance(BTC, &3), 0);
         assert_eq!(Tokens::reserved_balance(BTC, &3), 456);
 
         assert_eq!(Tokens::total_issuance(BTC), 579);


### PR DESCRIPTION
Every new amount of attested assets ares now automatically moved into the "reserved" set of balances