### PR TITLE
Weights for method calls

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,6 +44,4 @@ jobs:
           command: clippy
           args: --all-features -- -D warnings
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: ./scripts/checks.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "vec-arena",
 ]
 
@@ -234,7 +234,7 @@ dependencies = [
  "async-io",
  "futures-lite",
  "num_cpus",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
 ]
 
 [[package]]
@@ -249,7 +249,7 @@ dependencies = [
  "libc",
  "log",
  "nb-connect",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "parking",
  "polling",
  "vec-arena",
@@ -286,7 +286,7 @@ dependencies = [
  "log",
  "memchr",
  "num_cpus",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -560,7 +560,7 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
 ]
 
 [[package]]
@@ -840,7 +840,7 @@ dependencies = [
  "log",
  "regalloc",
  "serde",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "target-lexicon",
  "thiserror",
 ]
@@ -878,7 +878,7 @@ checksum = "2ef419efb4f94ecc02e5d9fbcc910d2bb7f0040e2de570e63a454f883bc891d6"
 dependencies = [
  "cranelift-codegen",
  "log",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "target-lexicon",
 ]
 
@@ -1480,11 +1480,11 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "log",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "parity-scale-codec",
  "paste",
  "serde",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "sp-arithmetic",
  "sp-core",
  "sp-inherents",
@@ -1742,7 +1742,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
 dependencies = [
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
 ]
 
 [[package]]
@@ -1974,7 +1974,7 @@ dependencies = [
  "http 0.2.1",
  "indexmap",
  "slab",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -2204,7 +2204,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.1",
  "socket2",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tower-service",
  "tracing",
  "want 0.3.0",
@@ -2223,7 +2223,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-rustls",
  "webpki",
 ]
@@ -2535,7 +2535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0315ef2f688e33844400b31f11c263f2b3dc21d8b9355c6891c5f185fae43f9a"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -2564,7 +2564,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -2642,7 +2642,7 @@ dependencies = [
  "parity-multiaddr",
  "parking_lot 0.10.2",
  "pin-project 0.4.27",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "wasm-timer",
 ]
 
@@ -2673,7 +2673,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2 0.8.2",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "thiserror",
  "unsigned-varint 0.4.0",
  "void",
@@ -2726,7 +2726,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -2750,7 +2750,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "unsigned-varint 0.4.0",
  "wasm-timer",
 ]
@@ -2767,7 +2767,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "wasm-timer",
 ]
 
@@ -2791,7 +2791,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "uint",
  "unsigned-varint 0.4.0",
  "void",
@@ -2815,7 +2815,7 @@ dependencies = [
  "log",
  "net2",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "void",
  "wasm-timer",
 ]
@@ -2920,7 +2920,7 @@ dependencies = [
  "lru 0.6.1",
  "minicbor",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "unsigned-varint 0.5.1",
  "wasm-timer",
 ]
@@ -2936,7 +2936,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "void",
  "wasm-timer",
 ]
@@ -3011,7 +3011,7 @@ checksum = "781d9b9f043dcdabc40640807125368596b849fd4d96cdca2dcf052fdf6f33fd"
 dependencies = [
  "futures 0.3.8",
  "libp2p-core",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "thiserror",
  "yamux",
 ]
@@ -3119,9 +3119,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard 1.1.0",
 ]
@@ -3334,7 +3334,7 @@ checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
  "mio",
- "miow 0.3.5",
+ "miow 0.3.6",
  "winapi 0.3.9",
 ]
 
@@ -3363,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -3408,7 +3408,7 @@ dependencies = [
  "futures 0.3.8",
  "log",
  "pin-project 1.0.1",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "unsigned-varint 0.5.1",
 ]
 
@@ -3591,11 +3591,11 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 dependencies = [
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
 ]
 
 [[package]]
@@ -3749,6 +3749,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-liquidity-provider"
+version = "0.1.0"
+dependencies = [
+ "arrayvec 0.5.2",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "lite-json",
+ "orml-tokens",
+ "orml-traits",
+ "pallet-membership",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "valiu-node-commons",
+]
+
+[[package]]
 name = "pallet-membership"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3761,26 +3784,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "pallet-provider"
-version = "0.1.0"
-dependencies = [
- "arrayvec 0.5.2",
- "frame-support",
- "frame-system",
- "lite-json",
- "orml-tokens",
- "orml-traits",
- "pallet-membership",
- "parity-scale-codec",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "valiu-node-commons",
 ]
 
 [[package]]
@@ -3863,7 +3866,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -3919,9 +3922,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.4"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fe99b938abd57507e37f8d4ef30cd74b33c71face2809b37b8beb71bab15ab"
+checksum = "43244a26dc1ddd3097216bb12eaa6cf8a07b060c72718d9ebd60fd297d6401df"
 dependencies = [
  "arrayref",
  "bs58 0.4.0",
@@ -3977,7 +3980,7 @@ dependencies = [
  "libc",
  "log",
  "mio-named-pipes",
- "miow 0.3.5",
+ "miow 0.3.6",
  "rand 0.7.3",
  "tokio 0.1.22",
  "tokio-named-pipes",
@@ -3997,7 +4000,7 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "winapi 0.3.9",
 ]
 
@@ -4075,12 +4078,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api 0.4.1",
+ "lock_api 0.4.2",
  "parking_lot_core 0.8.0",
 ]
 
@@ -4122,7 +4125,7 @@ dependencies = [
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "winapi 0.3.9",
 ]
 
@@ -4137,7 +4140,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "winapi 0.3.9",
 ]
 
@@ -4303,9 +4306,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "primitive-types"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55c21c64d0eaa4d7ed885d959ef2d62d9e488c27c0e02d9aa5ce6c877b7d5f8"
+checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -4376,7 +4379,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "fnv",
  "lazy_static",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "regex",
  "thiserror",
 ]
@@ -4764,7 +4767,7 @@ checksum = "b9ba8aaf5fe7cf307c6dbdaeed85478961d29e25e3bee5169e11b92fa9f027a8"
 dependencies = [
  "log",
  "rustc-hash",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -4824,13 +4827,13 @@ checksum = "e005d658ad26eacc2b6c506dfde519f4e277e328d0eb3379ca61647d70a8f531"
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "b72b84d47e8ec5a4f2872e8262b8f8256c5be1c938a7d6d3a867a3ba8f722f74"
 dependencies = [
  "cc",
  "libc",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "spin",
  "untrusted",
  "web-sys",
@@ -5073,7 +5076,7 @@ dependencies = [
  "structopt",
  "substrate-prometheus-endpoint",
  "time",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -6068,9 +6071,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "snow"
@@ -6092,9 +6095,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -6578,7 +6581,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
@@ -6861,14 +6864,14 @@ dependencies = [
  "hyper 0.13.9",
  "log",
  "prometheus",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
 name = "substrate-wasm-builder-runner"
-version = "1.0.6"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
+checksum = "54cab12167e32b38a62c5ea5825aa0874cde315f907a46aad2b05aa8ef3d862f"
 
 [[package]]
 name = "subtle"
@@ -7006,7 +7009,7 @@ checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
 dependencies = [
  "failure",
  "hmac",
- "once_cell 1.4.1",
+ "once_cell 1.5.2",
  "pbkdf2",
  "rand 0.7.3",
  "rustc-hash",
@@ -7025,9 +7028,18 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -7055,9 +7067,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -7190,7 +7202,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "webpki",
 ]
 
@@ -7311,7 +7323,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -7407,7 +7419,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -7425,7 +7437,7 @@ dependencies = [
  "hashbrown 0.8.2",
  "log",
  "rustc-hex",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
 ]
 
 [[package]]
@@ -7492,18 +7504,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "f1e9a0b71dba18b6fa17c7b3dcf1440bb3522552deb2f84bf47dabd9fb7e5570"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
 
 [[package]]
 name = "unicode-width"
@@ -7665,8 +7677,8 @@ dependencies = [
  "pallet-aura",
  "pallet-balances",
  "pallet-grandpa",
+ "pallet-liquidity-provider",
  "pallet-membership",
- "pallet-provider",
  "pallet-randomness-collective-flip",
  "pallet-sudo",
  "pallet-timestamp",
@@ -7808,7 +7820,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures 0.3.8",
  "js-sys",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -7864,7 +7876,7 @@ dependencies = [
  "log",
  "region",
  "rustc-demangle",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "target-lexicon",
  "wasmparser 0.59.0",
  "wasmtime-environ",
@@ -8163,7 +8175,7 @@ dependencies = [
  "futures 0.3.8",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "rand 0.7.3",
  "static_assertions",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -13,8 +13,8 @@ version = '2.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-frame-benchmarking = '2.0.0'
-frame-benchmarking-cli = '2.0.0'
+frame-benchmarking = { optional = true, version = '2.0.0' }
+frame-benchmarking-cli = { optional = true, version = '2.0.0' }
 jsonrpc-core = '15.0.0'
 pallet-membership = '2.0'
 pallet-transaction-payment-rpc = '2.0.0'
@@ -42,14 +42,19 @@ sp-runtime = '2.0.0'
 sp-transaction-pool = '2.0.0'
 structopt = '0.3.8'
 substrate-frame-rpc-system = '2.0.0'
-vln-runtime = { version = '2.0.0', path = '../runtime' }
+vln-runtime = { path = '../runtime', version = '2.0.0' }
 
 [build-dependencies]
 substrate-build-script-utils = '2.0.0'
 
 [features]
 default = []
-runtime-benchmarks = ['vln-runtime/runtime-benchmarks']
+native-runtime-benchmarks = ['runtime-benchmarks', 'vln-runtime/native-runtime-benchmarks']
+runtime-benchmarks = [
+    'frame-benchmarking-cli',
+    'frame-benchmarking',
+    'vln-runtime/runtime-benchmarks'
+]
 
 [[bin]]
 name = 'vln_node'

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -13,6 +13,7 @@ pub struct Cli {
 #[derive(Debug, StructOpt)]
 pub enum Subcommand {
     /// The custom benchmark subcommmand benchmarking runtime pallets.
+    #[cfg(feature = "runtime-benchmarks")]
     #[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
     Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -19,7 +19,6 @@ use crate::cli::{Cli, Subcommand};
 use crate::{chain_spec, service};
 use sc_cli::{ChainSpec, Role, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
-use vln_runtime::Block;
 
 impl SubstrateCli for Cli {
     fn author() -> String {
@@ -133,11 +132,12 @@ pub fn run() -> sc_cli::Result<()> {
                 Ok((cmd.run(client, backend), task_manager))
             })
         }
+        #[cfg(feature = "runtime-benchmarks")]
         Some(Subcommand::Benchmark(cmd)) => {
             if cfg!(feature = "runtime-benchmarks") {
                 let runner = cli.create_runner(cmd)?;
 
-                runner.sync_run(|config| cmd.run::<Block, service::Executor>(config))
+                runner.sync_run(|config| cmd.run::<vln_runtime::Block, service::Executor>(config))
             } else {
                 Err("Benchmarking wasn't enabled when building the node. \
 				You can enable it with `--features runtime-benchmarks`."

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -13,12 +13,19 @@ use std::sync::Arc;
 use std::time::Duration;
 use vln_runtime::{self, opaque::Block, RuntimeApi};
 
-// Our native executor instance.
+#[cfg(feature = "runtime-benchmarks")]
 native_executor_instance!(
-    pub Executor,
-    vln_runtime::api::dispatch,
-    vln_runtime::native_version,
-    frame_benchmarking::benchmarking::HostFunctions,
+  pub Executor,
+  vln_runtime::api::dispatch,
+  vln_runtime::native_version,
+  frame_benchmarking::benchmarking::HostFunctions,
+);
+
+#[cfg(not(feature = "runtime-benchmarks"))]
+native_executor_instance!(
+  pub Executor,
+  vln_runtime::api::dispatch,
+  vln_runtime::native_version,
 );
 
 type PartialTy = sc_service::PartialComponents<

--- a/pallets/liquidity-provider/Cargo.toml
+++ b/pallets/liquidity-provider/Cargo.toml
@@ -4,15 +4,24 @@ description = 'Mediums Ledger module'
 edition = '2018'
 homepage = 'https://github.com/valibre-org/node'
 license = 'Unlicense'
-name = 'pallet-provider'
+name = 'pallet-liquidity-provider'
 readme = 'README.md'
 repository = 'https://github.com/valibre-org/node'
 version = '0.1.0'
+
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
 [features]
 default = ['std']
+native-runtime-benchmarks = ['frame-benchmarking/std', 'runtime-benchmarks', 'std']
+runtime-benchmarks = [
+    'frame-benchmarking',
+    'frame-system/runtime-benchmarks',
+    'orml-tokens',
+    'sp-std',
+    'parity-util-mem'
+]
 std = [
     'arrayvec/std',
     'frame-support/std',
@@ -31,18 +40,23 @@ std = [
 
 [dependencies]
 arrayvec = { default-features = false, version = '0.5' }
+frame-benchmarking = { default-features = false, optional = true, version = '2.0' }
 frame-support = { default-features = false, version = '2.0' }
 frame-system = { default-features = false, version = '2.0'  }
 lite-json = { default-features = false, version = '0.1' }
+orml-tokens = { default-features = false, optional = true, version = '0.3' }
 orml-traits = { default-features = false, version = '0.3' }
 pallet-membership = { default-features = false, version = '2.0' }
+parity-util-mem = { default-features = false, optional = true, version = '0.7' }
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.0' }
 sp-application-crypto = { default-features = false, version = '2.0' }
 sp-arithmetic = { default-features = false, version = '2.0' }
 sp-core = { default-features = false, version = '2.0' }
 sp-io = { default-features = false, version = '2.0' }
 sp-runtime = { default-features = false, version = '2.0' }
+sp-std = { default-features = false, optional = true, version = '2.0' }
 valiu-node-commons = { default-features = false, path = '../../valiu-node-commons' }
 
 [dev-dependencies]
 orml-tokens = { default-features = false, version = '0.3' }
+parity-util-mem = { default-features = false, version = '0.7' }

--- a/pallets/liquidity-provider/src/benchmarks.rs
+++ b/pallets/liquidity-provider/src/benchmarks.rs
@@ -1,0 +1,83 @@
+use crate::{
+    mock::{root, Origin, ProviderMembers, TestProvider, USD_ASSET},
+    Balance, Call, Module, Trait,
+};
+use alloc::{boxed::Box, vec, vec::Vec};
+use frame_benchmarking::{benchmarks, whitelisted_caller};
+use frame_system::{offchain::SigningTypes, RawOrigin};
+use sp_core::sr25519;
+use valiu_node_commons::{Asset, Collateral, DistributionStrategy};
+
+benchmarks! {
+    where_clause {
+        where
+            <T as frame_system::Trait>::AccountId: AsRef<[u8; 32]>,
+            <T as SigningTypes>::Signature: From<sr25519::Signature>,
+    }
+
+    _ {}
+
+    attest {
+        let origin = gen_member_and_attest::<T>(USD_ASSET);
+        let balance = Balance::<T>::from(100);
+    }: attest(RawOrigin::Signed(origin), Asset::Collateral(Collateral::Usd), balance, Vec::new())
+    verify {
+    }
+
+    transfer {
+        let from = gen_member_and_attest::<T>(USD_ASSET);
+        let to: T::AccountId = whitelisted_caller();
+        let to_amount = Balance::<T>::from(100);
+        let ds = DistributionStrategy::Evenly;
+    }: transfer(RawOrigin::Signed(from), to, to_amount, ds)
+    verify {
+    }
+
+    update_offer_rates {
+        let from = gen_member_and_attest::<T>(USD_ASSET);
+    }: update_offer_rates(RawOrigin::Signed(from), Asset::Btc, Vec::new())
+    verify {
+    }
+}
+
+fn gen_member<T>() -> (T::AccountId, sr25519::Public)
+where
+    <T as frame_system::Trait>::AccountId: AsRef<[u8; 32]>,
+    T: Trait,
+{
+    let from: T::AccountId = whitelisted_caller();
+    let from_public = sr25519::Public::from_raw(*from.as_ref());
+    ProviderMembers::add_member(Origin::signed(root()), from_public).unwrap();
+    (from, from_public)
+}
+
+fn gen_member_and_attest<T>(asset: Asset) -> T::AccountId
+where
+    <T as frame_system::Trait>::AccountId: AsRef<[u8; 32]>,
+    T: Trait,
+{
+    let (from, from_public) = gen_member::<T>();
+    TestProvider::attest(Origin::signed(from_public), asset, 100, Default::default()).unwrap();
+    from
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        benchmarks::{
+            test_benchmark_attest, test_benchmark_transfer, test_benchmark_update_offer_rates,
+        },
+        mock::Test,
+        tests::new_test_ext,
+    };
+    use frame_support::assert_ok;
+
+    #[test]
+    fn benchmarks_generate_unit_tests() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_attest::<Test>());
+            assert_ok!(test_benchmark_transfer::<Test>());
+            assert_ok!(test_benchmark_update_offer_rates::<Test>());
+        });
+    }
+}

--- a/pallets/liquidity-provider/src/mock.rs
+++ b/pallets/liquidity-provider/src/mock.rs
@@ -1,15 +1,19 @@
-use crate::{Call, Module, Trait};
+mod test_extrinsic;
+
+use crate::{mock::test_extrinsic::TestXt, Call, DefaultWeightInfo, Module, Trait};
+use alloc::{boxed::Box, vec};
 use frame_support::{impl_outer_origin, ord_parameter_types, parameter_types, weights::Weight};
 use frame_system::{offchain::AppCrypto, EnsureSignedBy};
 use sp_core::{sr25519, H256};
 use sp_runtime::{
     generic::Header,
-    testing::TestXt,
-    traits::Verify,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, IdentityLookup, Verify},
     Perbill,
 };
-use valiu_node_commons::Asset;
+use valiu_node_commons::{Asset, Collateral};
+
+pub const USD_COLLATERAL: Collateral = Collateral::Usd;
+pub const USD_ASSET: Asset = Asset::Collateral(USD_COLLATERAL);
 
 pub type Extrinsic = TestXt<Call<Test>, ()>;
 pub type ProviderMembers = pallet_membership::Module<Test, pallet_membership::DefaultInstance>;
@@ -104,6 +108,7 @@ impl Trait for Test {
     type OffchainAuthority = TestAuth;
     type OffchainUnsignedGracePeriod = OffchainUnsignedGracePeriod;
     type OffchainUnsignedInterval = OffchainUnsignedInterval;
+    type WeightInfo = DefaultWeightInfo;
 }
 
 pub struct TestAuth;
@@ -114,10 +119,6 @@ impl AppCrypto<<sr25519::Signature as Verify>::Signer, sr25519::Signature> for T
     type RuntimeAppPublic = crate::Public;
 }
 
-// Build genesis storage according to the mock runtime.
-pub fn new_test_ext() -> sp_io::TestExternalities {
-    frame_system::GenesisConfig::default()
-        .build_storage::<Test>()
-        .unwrap()
-        .into()
+pub fn root() -> sr25519::Public {
+    <sr25519::Public>::from_raw([0; 32])
 }

--- a/pallets/liquidity-provider/src/mock/test_extrinsic.rs
+++ b/pallets/liquidity-provider/src/mock/test_extrinsic.rs
@@ -1,0 +1,114 @@
+//! Testing utilities.
+
+use core::fmt;
+use parity_scale_codec::{Codec, Decode, Encode};
+use sp_runtime::{
+    traits::{
+        Applyable, Checkable, DispatchInfoOf, Dispatchable, Extrinsic, PostDispatchInfoOf,
+        SignedExtension, ValidateUnsigned,
+    },
+    transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
+    ApplyExtrinsicResultWithInfo,
+};
+
+#[derive(PartialEq, Eq, Clone, Encode, Decode)]
+pub struct TestXt<Call, Extra> {
+    pub signature: Option<(u64, Extra)>,
+    pub call: Call,
+}
+
+impl<Origin, Call, Extra> Applyable for TestXt<Call, Extra>
+where
+    Call: 'static
+        + Clone
+        + Codec
+        + Dispatchable<Origin = Origin>
+        + Eq
+        + fmt::Debug
+        + Send
+        + Sized
+        + Sync,
+    Extra: SignedExtension<AccountId = u64, Call = Call>,
+    Origin: From<Option<u64>>,
+{
+    type Call = Call;
+
+    fn validate<U: ValidateUnsigned<Call = Self::Call>>(
+        &self,
+        _source: TransactionSource,
+        _info: &DispatchInfoOf<Self::Call>,
+        _len: usize,
+    ) -> TransactionValidity {
+        Ok(Default::default())
+    }
+
+    fn apply<U: ValidateUnsigned<Call = Self::Call>>(
+        self,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
+    ) -> ApplyExtrinsicResultWithInfo<PostDispatchInfoOf<Self::Call>> {
+        let maybe_who = if let Some((who, extra)) = self.signature {
+            Extra::pre_dispatch(extra, &who, &self.call, info, len)?;
+            Some(who)
+        } else {
+            Extra::pre_dispatch_unsigned(&self.call, info, len)?;
+            None
+        };
+
+        Ok(self.call.dispatch(maybe_who.into()))
+    }
+}
+
+impl<Call, Context, Extra> Checkable<Context> for TestXt<Call, Extra>
+where
+    Call: Codec + Sync + Send,
+{
+    type Checked = Self;
+    fn check(self, _: &Context) -> Result<Self::Checked, TransactionValidityError> {
+        Ok(self)
+    }
+}
+
+impl<Call, Extra> Extrinsic for TestXt<Call, Extra>
+where
+    Call: Codec + Sync + Send,
+{
+    type Call = Call;
+    type SignaturePayload = (u64, Extra);
+
+    fn is_signed(&self) -> Option<bool> {
+        Some(self.signature.is_some())
+    }
+
+    fn new(c: Call, sig: Option<Self::SignaturePayload>) -> Option<Self> {
+        Some(TestXt {
+            signature: sig,
+            call: c,
+        })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<Call, Extra> Serialize for TestXt<Call, Extra>
+where
+    TestXt<Call, Extra>: Encode,
+{
+    fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.using_encoded(|bytes| seq.serialize_bytes(bytes))
+    }
+}
+
+impl<Call, Extra> fmt::Debug for TestXt<Call, Extra> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TestXt({:?}, ...)",
+            self.signature.as_ref().map(|x| &x.0)
+        )
+    }
+}
+
+parity_util_mem::malloc_size_of_is_0!(any: TestXt<Call, Extra>);

--- a/pallets/liquidity-provider/src/tests.rs
+++ b/pallets/liquidity-provider/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     mock::{
-        new_test_ext, Extrinsic, Origin, ProviderMembers, Test, TestAuth, TestProvider, Tokens,
+        root, Extrinsic, Origin, ProviderMembers, Test, TestAuth, TestProvider, Tokens, USD_ASSET,
     },
     Call, OffchainPairPricesPayload,
 };
@@ -21,29 +21,9 @@ use valiu_node_commons::{
     AccountRate, Asset, Collateral, DistributionStrategy, OfferRate, PairPrice,
 };
 
-const USD_ASSET: Asset = Asset::Collateral(USD_COLLATERAL);
-const USD_COLLATERAL: Collateral = Collateral::Usd;
 const USDC_ASSET: Asset = Asset::Collateral(USDC_COLLATERAL);
 const USDC_COLLATERAL: Collateral = Collateral::Usdc;
 const USDV_ASSET: Asset = Asset::Usdv;
-
-fn alice() -> sr25519::Public {
-    <sr25519::Public>::from_raw({
-        let mut array = [0; 32];
-        array[31] = 2;
-        array
-    })
-}
-fn root() -> sr25519::Public {
-    <sr25519::Public>::from_raw([0; 32])
-}
-fn bob() -> sr25519::Public {
-    <sr25519::Public>::from_raw({
-        let mut array = [0; 32];
-        array[31] = 1;
-        array
-    })
-}
 
 #[test]
 fn attest_increases_usdv() {
@@ -211,7 +191,6 @@ fn usdv_transfer_also_transfers_collaterals() {
         let bob = bob();
 
         assert_ok!(ProviderMembers::add_member(Origin::signed(root()), alice));
-
         assert_ok!(ProviderMembers::add_member(Origin::signed(root()), bob));
 
         assert_ok!(TestProvider::attest(
@@ -266,4 +245,27 @@ fn parse_btc_usd_has_correct_behavior() {
         TestProvider::parse_btc_usd(r#"{"btc":{"btc":1,"usd":200},"usd":{"btc":2,"usd":1}}"#)
             .is_none()
     );
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap()
+        .into()
+}
+
+fn alice() -> sr25519::Public {
+    <sr25519::Public>::from_raw({
+        let mut array = [0; 32];
+        array[31] = 2;
+        array
+    })
+}
+
+fn bob() -> sr25519::Public {
+    <sr25519::Public>::from_raw({
+        let mut array = [0; 32];
+        array[31] = 1;
+        array
+    })
 }

--- a/pallets/liquidity-provider/src/weights.rs
+++ b/pallets/liquidity-provider/src/weights.rs
@@ -1,0 +1,28 @@
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+
+pub struct DefaultWeightInfo;
+
+impl WeightInfo for DefaultWeightInfo {
+    fn attest() -> Weight {
+        (163_972_000 as Weight)
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+    fn transfer() -> Weight {
+        (74_911_000 as Weight).saturating_add(DbWeight::get().reads(2 as Weight))
+    }
+    fn update_offer_rates() -> Weight {
+        (2_762_000 as Weight)
+    }
+}
+
+pub trait WeightInfo {
+    fn attest() -> Weight;
+    fn transfer() -> Weight;
+    fn update_offer_rates() -> Weight;
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,161 +6,66 @@ license = 'Unlicense'
 name = 'vln-runtime'
 repository = 'https://github.com/valibre-org/node'
 version = '2.0.0'
+
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
 
-[build-dependencies.wasm-builder-runner]
-package = "substrate-wasm-builder-runner"
-version = "1.0.6"
-[dependencies.codec]
-default-features = false
-features = ['derive']
-package = "parity-scale-codec"
-version = "1.3.5"
+[build-dependencies]
+substrate-wasm-builder-runner = { default-features = false, version = '2.0' }
 
-[dependencies.frame-benchmarking]
-default-features = false
-optional = true
-version = "2.0.0"
-
-[dependencies.frame-executive]
-default-features = false
-version = "2.0.0"
-
-[dependencies.frame-support]
-default-features = false
-version = "2.0.0"
-
-[dependencies.frame-system]
-default-features = false
-version = "2.0.0"
-
-[dependencies.frame-system-benchmarking]
-default-features = false
-optional = true
-version = "2.0.0"
-
-[dependencies.frame-system-rpc-runtime-api]
-default-features = false
-version = "2.0.0"
-
-[dependencies.hex-literal]
-optional = true
-version = "0.3.1"
-
-[dependencies.pallet-membership]
-default-features = false
-version = "2.0.0"
-
-[dependencies.pallet-aura]
-default-features = false
-version = "2.0.0"
-
-[dependencies.pallet-balances]
-default-features = false
-version = "2.0.0"
-
-[dependencies.pallet-grandpa]
-default-features = false
-version = "2.0.0"
-
-[dependencies.pallet-randomness-collective-flip]
-default-features = false
-version = "2.0.0"
-
-[dependencies.pallet-sudo]
-default-features = false
-version = "2.0.0"
-
-[dependencies.pallet-timestamp]
-default-features = false
-version = "2.0.0"
-
-[dependencies.pallet-transaction-payment]
-default-features = false
-version = "2.0.0"
-
-[dependencies.pallet-transaction-payment-rpc-runtime-api]
-default-features = false
-version = "2.0.0"
-
-[dependencies.serde]
-features = ['derive']
-optional = true
-version = "1.0.116"
-
-[dependencies.sp-api]
-default-features = false
-version = "2.0.0"
-
-[dependencies.sp-block-builder]
-default-features = false
-version = "2.0.0"
-
-[dependencies.sp-consensus-aura]
-default-features = false
-version = "0.8.0"
-
-[dependencies.sp-core]
-default-features = false
-version = "2.0.0"
-
-[dependencies.sp-inherents]
-default-features = false
-version = "2.0.0"
-
-[dependencies.sp-offchain]
-default-features = false
-version = "2.0.0"
-
-[dependencies.sp-runtime]
-default-features = false
-version = "2.0.0"
-
-[dependencies.sp-session]
-default-features = false
-version = "2.0.0"
-
-[dependencies.sp-std]
-default-features = false
-version = "2.0.0"
-
-[dependencies.sp-transaction-pool]
-default-features = false
-version = "2.0.0"
-
-[dependencies.sp-version]
-default-features = false
-version = "2.0.0"
-
-[dependencies.pallet-provider]
-default-features = false
-package = 'pallet-provider'
-path = '../pallets/liquidity-provider'
-version = '0.1.0'
-
-[dependencies.orml-tokens]
-default-features = false
-version = "0.3"
-
-[dependencies.valiu-node-commons]
-default-features = false
-path = '../valiu-node-commons'
+[dependencies]
+frame-benchmarking = { default-features = false, optional = true, version = '2.0' }
+frame-executive = { default-features = false, version = '2.0' }
+frame-support = { default-features = false, version = '2.0' }
+frame-system = { default-features = false, version = '2.0' }
+frame-system-benchmarking = { default-features = false, optional = true, version = '2.0' }
+frame-system-rpc-runtime-api = { default-features = false, version = '2.0' }
+hex-literal = { default-features = false, optional = true, version = '0.3' }
+orml-tokens = { default-features = false, version = '0.3' }
+pallet-aura = { default-features = false, version = '2.0' }
+pallet-balances = { default-features = false, version = '2.0' }
+pallet-grandpa = { default-features = false, version = '2.0' }
+pallet-liquidity-provider = { default-features = false, path = '../pallets/liquidity-provider' }
+pallet-membership = { default-features = false, version = '2.0' }
+pallet-randomness-collective-flip = { default-features = false, version = '2.0' }
+pallet-sudo = { default-features = false, version = '2.0' }
+pallet-timestamp = { default-features = false, version = '2.0' }
+pallet-transaction-payment = { default-features = false, version = '2.0' }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = '2.0' }
+parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3' }
+serde = { default-features = false, features = ['derive'], optional = true, version = '1.0' }
+sp-api = { default-features = false, version = '2.0' }
+sp-block-builder = { default-features = false, version = '2.0' }
+sp-consensus-aura = { default-features = false, version = '0.8' }
+sp-core = { default-features = false, version = '2.0' }
+sp-inherents = { default-features = false, version = '2.0' }
+sp-offchain = { default-features = false, version = '2.0' }
+sp-runtime = { default-features = false, version = '2.0' }
+sp-session = { default-features = false, version = '2.0' }
+sp-std = { default-features = false, version = '2.0' }
+sp-transaction-pool = { default-features = false, version = '2.0' }
+sp-version = { default-features = false, version = '2.0' }
+valiu-node-commons = { default-features = false, path = '../valiu-node-commons' }
 
 [features]
 default = ['std']
+native-runtime-benchmarks = [
+    'pallet-liquidity-provider/native-runtime-benchmarks',
+    'runtime-benchmarks',
+    'std',
+]
 runtime-benchmarks = [
-    'sp-runtime/runtime-benchmarks',
     'frame-benchmarking',
     'frame-support/runtime-benchmarks',
     'frame-system-benchmarking',
-    'hex-literal',
     'frame-system/runtime-benchmarks',
+    'hex-literal',
     'pallet-balances/runtime-benchmarks',
+    'pallet-liquidity-provider/runtime-benchmarks',
     'pallet-timestamp/runtime-benchmarks',
+    'sp-runtime/runtime-benchmarks',
 ]
 std = [
-    'codec/std',
     'frame-executive/std',
     'frame-support/std',
     'frame-system-rpc-runtime-api/std',
@@ -169,13 +74,14 @@ std = [
     'pallet-aura/std',
     'pallet-balances/std',
     'pallet-grandpa/std',
+    'pallet-liquidity-provider/std',
     'pallet-membership/std',
-    'pallet-provider/std',
     'pallet-randomness-collective-flip/std',
     'pallet-sudo/std',
     'pallet-timestamp/std',
     'pallet-transaction-payment-rpc-runtime-api/std',
     'pallet-transaction-payment/std',
+    'parity-scale-codec/std',
     'serde',
     'sp-api/std',
     'sp-block-builder/std',

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,4 +1,4 @@
-use wasm_builder_runner::WasmBuilder;
+use substrate_wasm_builder_runner::WasmBuilder;
 
 fn main() {
     WasmBuilder::new()

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eux
+
+check_package_with_feature() {
+    local package=$1
+    local features=$2
+
+    cargo check --manifest-path "${package}"/Cargo.toml --features "${features}" --no-default-features
+}
+
+check_package_with_feature valiu-node-commons default
+check_package_with_feature valiu-node-commons std
+
+check_package_with_feature pallets/liquidity-provider native-runtime-benchmarks
+check_package_with_feature pallets/liquidity-provider std
+
+check_package_with_feature runtime native-runtime-benchmarks
+check_package_with_feature runtime std
+
+check_package_with_feature node default
+check_package_with_feature node native-runtime-benchmarks
+


### PR DESCRIPTION
This PR uses the default Substrate benchmark framework to calculate a upper-bound weight for each public method call.

Weight is a unit of time and every signed extrinsic should have a weight to calculate fees or the average number of transactions for a block. The same necessity is true for unsigned transactions because theoretically anyone could submit infinite number of extrinsics inside a single block for anything that has `#[weight = 0]`.

Please, keep in mind that the current generated weights are based on my machine (Notebook with a i5-7200U processor) but the actual values should be generated from a reference hardware.

```bash
cargo run --release --features runtime-benchmarks -- benchmark --chain testnet_testnet --steps 50 --repeat 20 --pallet pallet_liquidity_provider --extrinsic "*" --wasm-execution=compiled --execution=wasm --output
```

To accomplish the benchmark structure, imports were re-arranged and more tests were included to enhance robustness. 

#### References:

https://substrate.dev/docs/en/knowledgebase/learn-substrate/weight
https://github.com/paritytech/substrate/tree/master/frame/benchmarking