### PR TITLE
Add valiu-node-rpc

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,3 +45,32 @@ jobs:
           args: --all-features -- -D warnings
 
       - run: ./scripts/tests.sh
+
+  integration-tests:
+    name: Integration tests
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal
+          target: wasm32-unknown-unknown
+          toolchain: nightly-2020-10-01
+
+      - name: Cache cargo directories
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }} 
+
+      - run: ./scripts/valiu-node-rpc-integration-tests.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,12 +301,24 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce6977f57fa68da77ffe5542950d47e9c23d65f5bc7cb0a9f8700996913eec7"
+dependencies = [
+ "futures 0.3.8",
+ "rustls 0.16.0",
+ "webpki",
+ "webpki-roots 0.17.0",
+]
+
+[[package]]
+name = "async-tls"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df097e3f506bec0e1a24f06bb3c962c228f36671de841ff579cb99f371772634"
 dependencies = [
  "futures 0.3.8",
- "rustls",
+ "rustls 0.18.1",
  "webpki",
  "webpki-roots 0.19.0",
 ]
@@ -376,6 +388,15 @@ name = "base58"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
+
+[[package]]
+name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder 1.3.4",
+]
 
 [[package]]
 name = "base64"
@@ -2017,6 +2038,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
+dependencies = [
+ "ahash 0.3.8",
+ "autocfg 1.0.1",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
@@ -2221,7 +2252,7 @@ dependencies = [
  "futures-util",
  "hyper 0.13.9",
  "log",
- "rustls",
+ "rustls 0.18.1",
  "rustls-native-certs",
  "tokio 0.2.23",
  "tokio-rustls",
@@ -2501,6 +2532,51 @@ dependencies = [
  "parity-ws",
  "parking_lot 0.10.2",
  "slab",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc8a1da5a54b417cfb7edb9f932024d833dc333de50c21c0e1b28d0e8b4f853"
+dependencies = [
+ "async-std",
+ "async-tls 0.6.0",
+ "bs58 0.3.1",
+ "bytes 0.5.6",
+ "fnv",
+ "futures 0.3.8",
+ "futures-timer 3.0.2",
+ "globset",
+ "hashbrown 0.7.2",
+ "hyper 0.13.9",
+ "jsonrpsee-proc-macros",
+ "lazy_static",
+ "log",
+ "parking_lot 0.10.2",
+ "pin-project 0.4.27",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "smallvec 1.5.0",
+ "soketto 0.3.2",
+ "thiserror",
+ "tokio 0.2.23",
+ "unicase",
+ "url 2.2.0",
+ "webpki",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ed1b5f6937dd2c6c79a9ac6e0e3f41bbc64edb5d443840bdc73e606009ed70"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2989,15 +3065,15 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d650534ebd99f48f6fa292ed5db10d30df2444943afde4407ceeddab8e513fca"
 dependencies = [
- "async-tls",
+ "async-tls 0.8.0",
  "either",
  "futures 0.3.8",
  "libp2p-core",
  "log",
  "quicksink",
- "rustls",
+ "rustls 0.18.1",
  "rw-stream-sink",
- "soketto",
+ "soketto 0.4.2",
  "url 2.2.0",
  "webpki",
  "webpki-roots 0.18.0",
@@ -3749,6 +3825,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-im-online"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a29b883f805fa2330742b5d99263eab68583e009be1a2420efab1c3237a08e5"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "serde",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-indices"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d234bf46076a835b473a987f089299ffa3efd961a92b5be9384cc280fcc8c8f"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-keyring",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-liquidity-provider"
 version = "0.1.0"
 dependencies = [
@@ -3821,6 +3934,27 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "sp-trie",
+]
+
+[[package]]
+name = "pallet-staking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d296b36c5c32d1e480de15d0bf08460bb6d8e1771d928a6017e88a6a1de6bf7"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "serde",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+ "static_assertions",
 ]
 
 [[package]]
@@ -4903,6 +5037,19 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
+dependencies = [
+ "base64 0.10.1",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
@@ -4921,7 +5068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls 0.18.1",
  "schannel",
  "security-framework",
 ]
@@ -5945,6 +6092,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6109,6 +6262,25 @@ dependencies = [
 
 [[package]]
 name = "soketto"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
+dependencies = [
+ "base64 0.11.0",
+ "bytes 0.5.6",
+ "futures 0.3.8",
+ "http 0.2.1",
+ "httparse",
+ "log",
+ "rand 0.7.3",
+ "sha1",
+ "smallvec 1.5.0",
+ "static_assertions",
+ "thiserror",
+]
+
+[[package]]
+name = "soketto"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
@@ -6189,6 +6361,19 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-debug-derive",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-authority-discovery"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7748c0e859bf4c3dda84849a72af83c9f85bb21a7b7c085ed161516fa00d1e"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -6288,6 +6473,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-consensus-babe"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8050a73302f354f45d0dee610e69ed39aadf43ab8a7528bdf3df8427276dc739"
+dependencies = [
+ "merlin",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus",
+ "sp-consensus-slots",
+ "sp-consensus-vrf",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+ "sp-timestamp",
+]
+
+[[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6295,6 +6500,19 @@ checksum = "83ea323ccf4ec8aad353fbc9016a1cb8cbf0d872d33bc8874cb0753b014fb7fc"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
+]
+
+[[package]]
+name = "sp-consensus-vrf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3345ee42ea5319bd6e3329bc3b5ee68b09f14d677378b27409a3a52d5ebe9990"
+dependencies = [
+ "parity-scale-codec",
+ "schnorrkel",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -6450,6 +6668,31 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "strum",
+]
+
+[[package]]
+name = "sp-npos-elections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54bb6d3d49dccf6ee26586a29ce8aabade8e102e51ed5009660ef7abb973eb7d"
+dependencies = [
+ "parity-scale-codec",
+ "serde",
+ "sp-arithmetic",
+ "sp-npos-elections-compact",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-npos-elections-compact"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d784c5576824b0ffa4cb359b7eebfd87511c49685b170b8214aabaa5f2454c87"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6870,6 +7113,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-subxt"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed693047c3c907a660aa97a71a30af33cec878316d75df60967d73b673ff4fd3"
+dependencies = [
+ "frame-metadata",
+ "frame-support",
+ "futures 0.3.8",
+ "hex",
+ "jsonrpsee",
+ "log",
+ "num-traits",
+ "pallet-im-online",
+ "pallet-indices",
+ "pallet-staking",
+ "parity-scale-codec",
+ "sc-rpc-api",
+ "serde",
+ "serde_json",
+ "sp-application-crypto",
+ "sp-authority-discovery",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-finality-grandpa",
+ "sp-rpc",
+ "sp-runtime",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
+ "substrate-subxt-proc-macro",
+ "thiserror",
+ "url 2.2.0",
+]
+
+[[package]]
+name = "substrate-subxt-proc-macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74975f373430ec447afaeb2925f2bac77e113733b08263f4df75e0a0e5998090"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "substrate-wasm-builder-runner"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7086,6 +7379,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
@@ -7165,6 +7459,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio-named-pipes"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7203,7 +7508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
- "rustls",
+ "rustls 0.18.1",
  "tokio 0.2.23",
  "webpki",
 ]
@@ -7604,6 +7909,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "valiu-node-rpc"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "sp-keyring",
+ "substrate-subxt",
+ "tokio 0.2.23",
+ "valiu-node-runtime-types",
+]
+
+[[package]]
+name = "valiu-node-runtime-types"
+version = "0.1.0"
+dependencies = [
+ "frame-executive",
+ "frame-system",
+ "pallet-balances",
+ "pallet-transaction-payment",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7661,6 +7989,7 @@ dependencies = [
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "valiu-node-runtime-types",
  "vln-runtime",
 ]
 
@@ -7696,11 +8025,11 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder-runner",
  "valiu-node-commons",
+ "valiu-node-runtime-types",
 ]
 
 [[package]]
@@ -8055,6 +8384,15 @@ checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a262ae37dd9d60f60dd473d1158f9fbebf110ba7b6a5051c8160460f6043718b"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     'node',
     'pallets/liquidity-provider',
     'runtime',
-    'valiu-node-commons',
+    'valiu-node-rpc',
+    'valiu-node-runtime-types',
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -43,6 +43,7 @@ sp-transaction-pool = '2.0.0'
 structopt = '0.3.8'
 substrate-frame-rpc-system = '2.0.0'
 vln-runtime = { path = '../runtime', version = '2.0.0' }
+valiu-node-runtime-types = { features = ['std'], path = '../valiu-node-runtime-types' }
 
 [build-dependencies]
 substrate-build-script-utils = '2.0.0'

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -8,9 +8,10 @@ use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::Ss58Codec, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
+use valiu_node_runtime_types::{AccountId, Signature};
 use vln_runtime::{
-    AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig,
-    SystemConfig, TokensConfig,
+    AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, SudoConfig, SystemConfig,
+    TokensConfig,
 };
 
 type AccountPublic = <Signature as Verify>::Signer;

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -11,7 +11,7 @@ use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_transaction_pool::TransactionPool;
 use std::sync::Arc;
-use vln_runtime::{opaque::Block, AccountId, Balance, Index};
+use valiu_node_runtime_types::{AccountId, Balance, Index, OpaqueBlock};
 
 /// Full client dependencies.
 pub struct FullDeps<C, P> {
@@ -26,12 +26,12 @@ pub struct FullDeps<C, P> {
 /// Instantiate all full RPC extensions.
 pub fn create_full<C, P>(deps: FullDeps<C, P>) -> jsonrpc_core::IoHandler<sc_rpc::Metadata>
 where
-    C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
-    C: ProvideRuntimeApi<Block>,
+    C: HeaderBackend<OpaqueBlock> + HeaderMetadata<OpaqueBlock, Error = BlockChainError> + 'static,
+    C: ProvideRuntimeApi<OpaqueBlock>,
     C: Send + Sync + 'static,
-    C::Api: BlockBuilder<Block>,
-    C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
-    C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
+    C::Api: BlockBuilder<OpaqueBlock>,
+    C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<OpaqueBlock, Balance>,
+    C::Api: substrate_frame_rpc_system::AccountNonceApi<OpaqueBlock, AccountId, Index>,
     P: TransactionPool + 'static,
 {
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -11,7 +11,8 @@ use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
 use sp_inherents::InherentDataProviders;
 use std::sync::Arc;
 use std::time::Duration;
-use vln_runtime::{self, opaque::Block, RuntimeApi};
+use valiu_node_runtime_types::OpaqueBlock;
+use vln_runtime::{self, RuntimeApi};
 
 #[cfg(feature = "runtime-benchmarks")]
 native_executor_instance!(
@@ -32,31 +33,31 @@ type PartialTy = sc_service::PartialComponents<
     FullClient,
     FullBackend,
     FullSelectChain,
-    sp_consensus::DefaultImportQueue<Block, FullClient>,
-    sc_transaction_pool::FullPool<Block, FullClient>,
+    sp_consensus::DefaultImportQueue<OpaqueBlock, FullClient>,
+    sc_transaction_pool::FullPool<OpaqueBlock, FullClient>,
     (
         sc_consensus_aura::AuraBlockImport<
-            Block,
+            OpaqueBlock,
             FullClient,
             sc_finality_grandpa::GrandpaBlockImport<
                 FullBackend,
-                Block,
+                OpaqueBlock,
                 FullClient,
                 FullSelectChain,
             >,
             AuraPair,
         >,
-        sc_finality_grandpa::LinkHalf<Block, FullClient, FullSelectChain>,
+        sc_finality_grandpa::LinkHalf<OpaqueBlock, FullClient, FullSelectChain>,
     ),
 >;
-type FullClient = sc_service::TFullClient<Block, RuntimeApi, Executor>;
-type FullBackend = sc_service::TFullBackend<Block>;
-type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
+type FullClient = sc_service::TFullClient<OpaqueBlock, RuntimeApi, Executor>;
+type FullBackend = sc_service::TFullBackend<OpaqueBlock>;
+type FullSelectChain = sc_consensus::LongestChain<FullBackend, OpaqueBlock>;
 
 /// Builds a new service for a light client.
 pub fn new_light(config: Configuration) -> Result<TaskManager, ServiceError> {
     let (client, backend, keystore, mut task_manager, on_demand) =
-        sc_service::new_light_parts::<Block, RuntimeApi, Executor>(&config)?;
+        sc_service::new_light_parts::<OpaqueBlock, RuntimeApi, Executor>(&config)?;
 
     let transaction_pool = Arc::new(sc_transaction_pool::BasicPool::new_light(
         config.transaction_pool.clone(),
@@ -139,7 +140,7 @@ pub fn new_partial(config: &Configuration) -> Result<PartialTy, ServiceError> {
     let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
     let (client, backend, keystore, task_manager) =
-        sc_service::new_full_parts::<Block, RuntimeApi, Executor>(&config)?;
+        sc_service::new_full_parts::<OpaqueBlock, RuntimeApi, Executor>(&config)?;
     let client = Arc::new(client);
 
     let select_chain = sc_consensus::LongestChain::new(backend.clone());

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -42,10 +42,10 @@ sp-inherents = { default-features = false, version = '2.0' }
 sp-offchain = { default-features = false, version = '2.0' }
 sp-runtime = { default-features = false, version = '2.0' }
 sp-session = { default-features = false, version = '2.0' }
-sp-std = { default-features = false, version = '2.0' }
 sp-transaction-pool = { default-features = false, version = '2.0' }
 sp-version = { default-features = false, version = '2.0' }
 valiu-node-commons = { default-features = false, path = '../valiu-node-commons' }
+valiu-node-runtime-types = { default-features = false, path = '../valiu-node-runtime-types' }
 
 [features]
 default = ['std']
@@ -91,8 +91,8 @@ std = [
     'sp-offchain/std',
     'sp-runtime/std',
     'sp-session/std',
-    'sp-std/std',
     'sp-transaction-pool/std',
     'sp-version/std',
     'valiu-node-commons/std',
+    'valiu-node-runtime-types/std',
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -11,15 +11,15 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 extern crate alloc;
 
 mod opaque {
-    use alloc::vec::Vec;
     use crate::{impl_opaque_keys, Aura, Grandpa};
-    
+    use alloc::vec::Vec;
+
     impl_opaque_keys! {
         pub struct SessionKeys {
             pub aura: Aura,
             pub grandpa: Grandpa,
         }
-    }    
+    }
 }
 
 use alloc::{boxed::Box, vec::Vec};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -8,8 +8,19 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-pub mod opaque;
+extern crate alloc;
 
+mod opaque;
+
+use alloc::{boxed::Box, vec::Vec};
+use frame_support::{
+    construct_runtime, parameter_types,
+    traits::{KeyOwnerProofSystem, Randomness},
+    weights::{
+        constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+        IdentityFee, Weight,
+    },
+};
 use frame_system::EnsureRoot;
 use pallet_grandpa::{
     fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
@@ -17,41 +28,22 @@ use pallet_grandpa::{
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_runtime::traits::{
-    BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, Saturating, Verify,
-};
 use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
+    traits::{BlakeTwo256, Block as BlockT, IdentityLookup, NumberFor, Saturating, Verify},
     transaction_validity::{TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult, MultiSignature, MultiSigner,
+    ApplyExtrinsicResult, MultiSignature, MultiSigner, Perbill,
 };
-use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use valiu_node_commons::Asset;
-
-// A few exports that help ease life for downstream crates.
-pub use frame_support::{
-    construct_runtime, parameter_types,
-    traits::{KeyOwnerProofSystem, Randomness},
-    weights::{
-        constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
-        IdentityFee, Weight,
-    },
-    RuntimeDebug, StorageValue,
+use valiu_node_runtime_types::{
+    AccountData, AccountId, Balance, BlockNumber, Hash, Index, Signature,
 };
-pub use pallet_balances::Call as BalancesCall;
-pub use pallet_timestamp::Call as TimestampCall;
-#[cfg(any(feature = "std", test))]
-pub use sp_runtime::BuildStorage;
-pub use sp_runtime::{Perbill, Permill};
 
-pub const DAYS: BlockNumber = HOURS * 24;
-pub const HOURS: BlockNumber = MINUTES * 60;
-pub const MILLISECS_PER_BLOCK: u64 = 6000;
-pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
-pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
+const MILLISECS_PER_BLOCK: u64 = 6000;
+const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     apis: RUNTIME_API_VERSIONS,
     authoring_version: 1,
@@ -62,72 +54,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     transaction_version: 1,
 };
 
-/// Some way of identifying an account on the chain. We intentionally make it equivalent
-/// to the public key of our transaction signing scheme.
-pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
-
-/// The type for looking up accounts. We don't expect more than 4 billion of them, but you
-/// never know...
-pub type AccountIndex = u32;
-
-/// The address format for describing accounts.
-pub type Address = AccountId;
-
-/// Balance of an account.
-pub type Balance = u128;
-
-/// Block type as expected by this runtime.
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-
-/// BlockId type as expected by this runtime.
-pub type BlockId = generic::BlockId<Block>;
-
-/// An index to a block.
-pub type BlockNumber = u32;
-
-/// Extrinsic type that has already been checked.
-pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExtra>;
-
-/// Digest item type.
-pub type DigestItem = generic::DigestItem<Hash>;
-
-/// Executive: handles dispatch to the various modules.
-pub type Executive = frame_executive::Executive<
-    Runtime,
-    Block,
-    frame_system::ChainContext<Runtime>,
-    Runtime,
-    AllModules,
->;
-
-/// A hash of some data used by the chain.
-pub type Hash = sp_core::H256;
-
-/// Block header type as expected by this runtime.
-pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-
-/// Index of a transaction in the chain.
-pub type Index = u32;
-
-/// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
-pub type Signature = MultiSignature;
-
-/// The SignedExtension to the basic transaction logic.
-pub type SignedExtra = (
-    frame_system::CheckSpecVersion<Runtime>,
-    frame_system::CheckTxVersion<Runtime>,
-    frame_system::CheckGenesis<Runtime>,
-    frame_system::CheckEra<Runtime>,
-    frame_system::CheckNonce<Runtime>,
-    frame_system::CheckWeight<Runtime>,
-    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-);
-
-/// A Block signed with a Justification
-pub type SignedBlock = generic::SignedBlock<Block>;
-
-/// Unchecked extrinsic type as expected by this runtime.
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
+pub type Block = valiu_node_runtime_types::Block<Call, Runtime>;
+type Executive = valiu_node_runtime_types::Executive<AllModules, Call, Runtime>;
+type UncheckedExtrinsic = valiu_node_runtime_types::UncheckedExtrinsic<Call, Runtime>;
 
 parameter_types! {
     pub MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get().saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
@@ -151,21 +80,20 @@ construct_runtime!(
    pub enum Runtime
    where
         Block = Block,
-        NodeBlock = opaque::Block,
+        NodeBlock = Block,
         UncheckedExtrinsic = UncheckedExtrinsic
     {
-        System: frame_system::{Module, Call, Config, Storage, Event<T>},
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
-        Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
-        Aura: pallet_aura::{Module, Config<T>, Inherent},
-        Grandpa: pallet_grandpa::{Module, Call, Storage, Config, Event},
-        Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
-        TransactionPayment: pallet_transaction_payment::{Module, Storage},
-        Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
-
+        Aura: pallet_aura::{Config<T>, Module, Inherent},
+        Balances: pallet_balances::{Call, Config<T>, Event<T>, Module, Storage},
+        Grandpa: pallet_grandpa::{Call, Config, Event, Module, Storage},
         LiquidityProvider: pallet_liquidity_provider::{Call, Event<T>, Module, Storage},
-        ProviderMembers: pallet_membership::{Module, Call, Storage, Event<T>, Config<T>},
-        Tokens: orml_tokens::{Module, Storage, Call, Event<T>, Config<T>},
+        ProviderMembers: pallet_membership::{Call, Config<T>, Event<T>, Module},
+        RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Call, Module, Storage},
+        Sudo: pallet_sudo::{Call, Config<T>, Event<T>, Module, Storage},
+        System: frame_system::{Call, Config, Event<T>, Module, Storage},
+        Timestamp: pallet_timestamp::{Call, Module, Inherent, Storage},
+        Tokens: orml_tokens::{Config<T>, Event<T>, Module},
+        TransactionPayment: pallet_transaction_payment::{Module, Storage},
     }
 );
 
@@ -384,7 +312,7 @@ impl frame_system::Trait for Runtime {
     /// What to do if an account is fully reaped from the system.
     type OnKilledAccount = ();
     /// The data to be stored in an account.
-    type AccountData = pallet_balances::AccountData<Balance>;
+    type AccountData = AccountData;
     /// Weight information for the extrinsics of this pallet.
     type SystemWeightInfo = ();
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -10,7 +10,17 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 extern crate alloc;
 
-mod opaque;
+mod opaque {
+    use alloc::vec::Vec;
+    use crate::{impl_opaque_keys, Aura, Grandpa};
+    
+    impl_opaque_keys! {
+        pub struct SessionKeys {
+            pub aura: Aura,
+            pub grandpa: Grandpa,
+        }
+    }    
+}
 
 use alloc::{boxed::Box, vec::Vec};
 use frame_support::{

--- a/runtime/src/opaque.rs
+++ b/runtime/src/opaque.rs
@@ -1,13 +1,5 @@
-use super::*;
-
-pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
-
-/// Opaque block type.
-pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-/// Opaque block identifier type.
-pub type BlockId = generic::BlockId<Block>;
-/// Opaque block header type.
-pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+use crate::{impl_opaque_keys, Aura, Grandpa};
+use alloc::vec::Vec;
 
 impl_opaque_keys! {
     pub struct SessionKeys {

--- a/runtime/src/opaque.rs
+++ b/runtime/src/opaque.rs
@@ -1,9 +1,0 @@
-use crate::{impl_opaque_keys, Aura, Grandpa};
-use alloc::vec::Vec;
-
-impl_opaque_keys! {
-    pub struct SessionKeys {
-        pub aura: Aura,
-        pub grandpa: Grandpa,
-    }
-}

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -9,7 +9,6 @@ export RUSTFLAGS='
     -D nonstandard_style
     -D rust_2018_compatibility
     -D rust_2018_idioms
-    -D unused_lifetimes
     -D unused_qualifications
     -D warnings
 '
@@ -18,8 +17,11 @@ test_package_with_feature() {
     local package=$1
     local features=$2
 
-    cargo test --manifest-path "${package}"/Cargo.toml --features "${features}" --no-default-features
+    cargo clippy --features $features --manifest-path $package/Cargo.toml
+    cargo test --features $features --manifest-path $package/Cargo.toml --no-default-features
 }
+
+cargo fmt --all -- --check
 
 test_package_with_feature valiu-node-commons default
 test_package_with_feature valiu-node-commons std

--- a/scripts/valiu-node-rpc-integration-tests.sh
+++ b/scripts/valiu-node-rpc-integration-tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+cargo build --release
+cargo test --manifest-path valiu-node-rpc/Cargo.toml --no-run
+cargo run --release -- --dev &
+sleep 1
+cargo test --manifest-path valiu-node-rpc/Cargo.toml
+pkill vln_node

--- a/valiu-node-commons/Cargo.toml
+++ b/valiu-node-commons/Cargo.toml
@@ -17,14 +17,13 @@ std = [
 
 [package]
 authors = ['The Valiu team']
-description = 'Valiu node commons'
+categories = ['configuration']
+description = 'Valiu node - Commons'
 edition = '2018'
-homepage = 'https://github.com/valibre-org/node'
+keywords = ['blockchain', 'valiu']
 license = 'Unlicense'
 name = 'valiu-node-commons'
 readme = 'README.md'
 repository = 'https://github.com/valibre-org/node'
 version = '0.1.0'
 
-[package.metadata.docs.rs]
-targets = ['x86_64-unknown-linux-gnu']

--- a/valiu-node-rpc/Cargo.toml
+++ b/valiu-node-rpc/Cargo.toml
@@ -1,0 +1,24 @@
+[dependencies]
+parity-scale-codec = { default-features = false, features = ['derive', 'std'], version = '1.0' }
+substrate-subxt = { default-features = false, version = '0.13' }
+valiu-node-runtime-types = { default-features = false, features = ['std'], path = '../valiu-node-runtime-types' }
+
+[dev-dependencies]
+sp-keyring = { default-features = false, version = '2.0' }
+tokio = { default-features = false, features = ["macros", "rt-core"], version = '0.2' }
+
+[features]
+default = []
+_integration-tests = []
+
+[package]
+authors = ['The Valiu team']
+categories = ['configuration']
+description = 'Valiu node - Remote procedure calls'
+edition = '2018'
+keywords = ['blockchain', 'valiu']
+license = 'Unlicense'
+name = 'valiu-node-rpc'
+readme = 'README.md'
+repository = 'https://github.com/valibre-org/node'
+version = '0.1.0'

--- a/valiu-node-rpc/src/lib.rs
+++ b/valiu-node-rpc/src/lib.rs
@@ -1,0 +1,9 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+mod membership;
+mod valiu_runtime;
+
+pub use membership::{AddMemberCall, Membership};
+pub use valiu_runtime::ValiuRuntime;

--- a/valiu-node-rpc/src/membership.rs
+++ b/valiu-node-rpc/src/membership.rs
@@ -1,0 +1,11 @@
+use alloc::boxed::Box;
+use substrate_subxt::system::{System, SystemEventsDecoder};
+
+#[substrate_subxt::module]
+pub trait Membership: System {}
+
+#[derive(Clone, Debug, PartialEq, parity_scale_codec::Encode, substrate_subxt::Call)]
+pub struct AddMemberCall<T: Membership> {
+    pub origin: <T as System>::Address,
+    pub who: <T as System>::Address,
+}

--- a/valiu-node-rpc/src/valiu_runtime.rs
+++ b/valiu-node-rpc/src/valiu_runtime.rs
@@ -1,0 +1,32 @@
+use crate::Membership;
+use substrate_subxt::{balances::Balances, extrinsic::DefaultExtra, system::System, Runtime};
+use valiu_node_runtime_types::{
+    AccountData, AccountId, Address, Balance, BlockNumber, Hash, Hashing, Header, Index,
+    OpaqueExtrinsic, Signature,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValiuRuntime;
+
+impl Balances for ValiuRuntime {
+    type Balance = Balance;
+}
+
+impl Membership for ValiuRuntime {}
+
+impl Runtime for ValiuRuntime {
+    type Extra = DefaultExtra<Self>;
+    type Signature = Signature;
+}
+
+impl System for ValiuRuntime {
+    type AccountData = AccountData;
+    type AccountId = AccountId;
+    type Address = Address;
+    type BlockNumber = BlockNumber;
+    type Extrinsic = OpaqueExtrinsic;
+    type Hash = Hash;
+    type Hashing = Hashing;
+    type Header = Header;
+    type Index = Index;
+}

--- a/valiu-node-rpc/tests/add_member.rs
+++ b/valiu-node-rpc/tests/add_member.rs
@@ -1,0 +1,23 @@
+#![cfg(feature = "_integration-tests")]
+
+use sp_keyring::AccountKeyring;
+use substrate_subxt::{extrinsic::PairSigner, ClientBuilder};
+use valiu_node_rpc::{AddMemberCall, ValiuRuntime};
+
+#[tokio::test]
+async fn add_member() {
+    let signer = PairSigner::new(AccountKeyring::Alice.pair());
+
+    let client = ClientBuilder::<ValiuRuntime>::new().build().await.unwrap();
+
+    let encoded = client
+        .encode(AddMemberCall {
+            origin: AccountKeyring::Alice.to_account_id(),
+            who: AccountKeyring::Bob.to_account_id(),
+        })
+        .unwrap();
+
+    let signed = client.create_signed(encoded, &signer).await.unwrap();
+
+    let _ = client.submit_extrinsic(signed).await.unwrap();
+}

--- a/valiu-node-runtime-types/Cargo.toml
+++ b/valiu-node-runtime-types/Cargo.toml
@@ -1,0 +1,29 @@
+[dependencies]
+frame-executive = { default-features = false, version = '2.0' }
+frame-system = { default-features = false, version = '2.0' }
+pallet-balances = { default-features = false, version = '2.0' }
+pallet-transaction-payment = { default-features = false, version = '2.0' }
+sp-core = { default-features = false, version = '2.0' }
+sp-runtime = { default-features = false, version = '2.0' }
+
+[features]
+default = []
+std = [
+    'frame-executive/std',
+    'frame-system/std',
+    'pallet-transaction-payment/std',
+    'sp-core/std',
+    'sp-runtime/std',
+]
+
+[package]
+authors = ['The Valiu team']
+categories = ['configuration']
+description = 'Valiu node - Runtime types'
+edition = '2018'
+keywords = ['blockchain', 'valiu']
+license = 'Unlicense'
+name = 'valiu-node-runtime-types'
+readme = 'README.md'
+repository = 'https://github.com/valibre-org/node'
+version = '0.1.0'

--- a/valiu-node-runtime-types/src/lib.rs
+++ b/valiu-node-runtime-types/src/lib.rs
@@ -1,0 +1,89 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_system::{
+    ChainContext, CheckEra, CheckGenesis, CheckNonce, CheckSpecVersion, CheckTxVersion, CheckWeight,
+};
+use pallet_transaction_payment::ChargeTransactionPayment;
+use sp_core::H256;
+use sp_runtime::{
+    generic,
+    traits::{BlakeTwo256, IdentifyAccount, Verify},
+    MultiSignature,
+};
+
+/// Account data
+pub type AccountData = pallet_balances::AccountData<Balance>;
+
+/// Some way of identifying an account on the chain. We intentionally make it equivalent
+/// to the public key of our transaction signing scheme.
+pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
+/// The type for looking up accounts. We don't expect more than 4 billion of them, but you
+/// never know...
+pub type AccountIndex = u32;
+
+/// The address format for describing accounts.
+pub type Address = AccountId;
+
+/// Balance of an account.
+pub type Balance = u128;
+
+/// Block type as expected by the runtime.
+pub type Block<C, R> = generic::Block<Header, UncheckedExtrinsic<C, R>>;
+
+/// BlockId type as expected by the runtime.
+pub type BlockId<C, R> = generic::BlockId<Block<C, R>>;
+
+/// An index to a block.
+pub type BlockNumber = u32;
+
+/// Extrinsic type that has already been checked.
+pub type CheckedExtrinsic<C, R> = generic::CheckedExtrinsic<AccountId, C, SignedExtra<R>>;
+
+/// Digest item type.
+pub type DigestItem = generic::DigestItem<Hash>;
+
+/// Executive: handles dispatch to the various modules.
+pub type Executive<AM, C, R> = frame_executive::Executive<R, Block<C, R>, ChainContext<R>, R, AM>;
+
+/// A hash of some data used by the chain.
+pub type Hash = H256;
+
+/// Hashing algorithm
+pub type Hashing = BlakeTwo256;
+
+/// Block header type as expected by the runtime.
+pub type Header = generic::Header<BlockNumber, Hashing>;
+
+/// Index of a transaction in the chain.
+pub type Index = u32;
+
+/// Opaque block type.
+pub type OpaqueBlock = generic::Block<Header, OpaqueExtrinsic>;
+
+/// Opaque block identifier type.
+pub type OpaqueBlockId = generic::BlockId<OpaqueExtrinsic>;
+
+/// Opaque extrinsic
+pub type OpaqueExtrinsic = sp_runtime::OpaqueExtrinsic;
+
+/// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
+pub type Signature = MultiSignature;
+
+/// A Block signed with a Justification
+pub type SignedBlock<C, R> = generic::SignedBlock<Block<C, R>>;
+
+/// The SignedExtension to the basic transaction logic.
+pub type SignedExtra<R> = (
+    CheckSpecVersion<R>,
+    CheckTxVersion<R>,
+    CheckGenesis<R>,
+    CheckEra<R>,
+    CheckNonce<R>,
+    CheckWeight<R>,
+    ChargeTransactionPayment<R>,
+);
+
+/// Unchecked extrinsic type as expected by the runtime.
+pub type UncheckedExtrinsic<C, R> =
+    generic::UncheckedExtrinsic<Address, C, Signature, SignedExtra<R>>;


### PR DESCRIPTION
`valiu-node-rpc` is a new crate intended to communicate with valiu node through external RPC calls using `substrate-subxt` or in other words, a client that can be incorporated into libraries or binaries.

Since `substrate-subxt` expects the same runtime definitions of valiu, all common types were moved into a common `valiu-node-ruintime-types` dependency where both `valiu-node-rpc` and `runtime` depends and builds upon it.

Beyond the new crates, this PR brings overall architecture, an HTTP `add_member` integration test that includes new "attesting" members and CI checks.